### PR TITLE
Update runner.js

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -88,10 +88,13 @@ class Runner {
 
                 let maxWarnings;
 
+                //maxWarnings is either defined OR it is not.
+                //IF it is defined then set maxWarnings to the desired amount
                 if (isFinite(this.options.maxWarnings)) {
                     maxWarnings = parseInt(this.options.maxWarnings, 10) || 0;
                 } else {
-                    maxWarnings = new Boolean(this.options.maxWarnings) ? 0 : -1;
+                    //ELSE allow any number of warnings to pass through without breaking the build
+                    maxWarnings = -1;
                 }
 
                 if (maxWarnings === -1) {


### PR DESCRIPTION
Modified maxWarnings. new Boolean constructor is always returning true within a ternary despite having a false value. Functionality doesn't change, user still does not declare the --max-warnings flag to allow any number of warnings to pass through the build. If the --max-warnings flag has a value defined then it will break when limit is met.

**Which issue, if any, does this resolve?**
#321
**Is there anything in this PR that needs extra explaining or should something specific be focused on?** 
Should be rather self explanitory.
